### PR TITLE
apeye-core 1.1.5 (tests) :snowflake:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 5de72ed3d00cc9b20fea55e54b7ab8f5ef8500eb33a5368bc162a5585e238a55
+  url: https://github.com/domdfcoding/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 40a7633ccc60eb521be71e14cfe03ad5da342514cd9539ada29041530383a943
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<36]
 
@@ -29,13 +29,18 @@ requirements:
     - python >=3.6.1
 
 test:
+  source_files:
+    - tests
   imports:
     - apeye_core
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v tests
   requires:
     - pip
+    - pytest >=6.0.0
+    - coincidence >=0.2.0
 
 about:
   home: https://github.com/domdfcoding/apeye-core


### PR DESCRIPTION
apeye-core 1.1.5 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-8205]
- dev_url:        https://github.com/domdfcoding/apeye-core/tree/v1.1.5
- conda_forge:    None
- pypi:           https://pypi.org/project/apeye-core/1.1.5
- pypi inspector: https://inspector.pypi.io/project/apeye-core/1.1.5/packages/e5/4c/4f108cfd06923bd897bf992a6ecb6fb122646ee7af94d7f9a64abd071d4c/apeye_core-1.1.5.tar.gz/

### Explanation of changes:

- new version number


[PKG-8205]: https://anaconda.atlassian.net/browse/PKG-8205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ